### PR TITLE
read redis info from redis url

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ Set environment variables on your system or add an `.env` file to the root direc
   - `MONGODB_URL=mongodb://user:pass@example.com:11111/db_name` if you use MongoDb
   - `AREA_LIMIT=500000` The area limit in (sq. km) for use in geo-spatial queries.
   - `REDIS_USE=true` Whether to active the caching. Default is false.
-  - `REDIS_HOST=127.0.0.1` default is `127.0.0.1`
-  - `REDIS_PASSWORD=redispassword` Redis db password. Default is null.
-  - `REDIS_DATABASE=myredisdb` Name of the redis db. Default is null.
-  - `REDIS_PORT=6379` Redis port. Default is 6379.
+  - `REDIS_URL=redis://user:pass@example.com:8169` default is null
   - `LANDSAT_PAYLOAD_LIMIT` Limit of payload size for POST in bytes. Default is 2048000.
 
 #### Run

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mongodb": "^2.0.42",
     "monquery": "^0.2.0",
     "nock": "^2.9.1",
+    "redis-url": "^1.2.1",
     "request": "^2.57.0",
     "tmp": "0.0.27",
     "turf-area": "^1.1.1",


### PR DESCRIPTION
Supports Heroku's redis url env variable. 

With this change, there is no need to set/change the redis host/port/password env variables and also it protects the system in instances where the redis_url is updated.

@jflasher 
